### PR TITLE
open .csv files in universal newline mode

### DIFF
--- a/dataactvalidator/filestreaming/schemaLoader.py
+++ b/dataactvalidator/filestreaming/schemaLoader.py
@@ -26,7 +26,7 @@ class SchemaLoader(object):
         database.removeRulesByFileType(fileTypeName)
         database.removeColumnsByFileType(fileTypeName)
         #Step 2 add the new fields
-        with open(schemaFileName) as csvfile:
+        with open(schemaFileName, 'rU') as csvfile:
             reader = csv.DictReader(csvfile)
             for record in reader:
                 record = FieldCleaner.cleanRecord(record)


### PR DESCRIPTION
This patch fixes an issue I found when working on the unit tests. If I opened and saved one of the test .csv files on a mac, the validator got a newline error the next time it tried to read it.

@kaitlin submitting the PR now because this bit us on the prototype broker too, so it's a matter of time before someone else hits the problem.

Should we be logging these small things in GitHub? JIRA?