### PR TITLE
update config file names and add tas to config so init script can run…

### DIFF
--- a/dataactvalidator/scripts/baseScript.py
+++ b/dataactvalidator/scripts/baseScript.py
@@ -48,14 +48,14 @@ def loadValidator():
     validator_config_path = os.path.join(
         os.path.dirname(dataactvalidator.__file__), "config")
 
-    appropriationsFields = os.path.join(validator_config_path, "appropriationsFields.csv")
+    appropriationsFields = os.path.join(validator_config_path, "appropFields.csv")
     try:
         SchemaLoader.loadFields("appropriations", appropriationsFields)
     except IOError:
         print("Can't open file: {}".format(appropriationsFields))
 
 
-    appropriationsRules = os.path.join(validator_config_path, "appropriationsRules.csv")
+    appropriationsRules = os.path.join(validator_config_path, "appropRules.csv")
     try:
         SchemaLoader.loadRules("appropriations", appropriationsRules)
     except IOError:


### PR DESCRIPTION
… out of the box

There were a few old filenames in the validator's setup script that cause errors on a fresh install. This fixes those and adds the TAS file to config so users can run validator setup without the manual TAS download (until the story that automates a fresh TAS download hits the board).