### PR TITLE
pass db config to baseInterface, similar to dbame

### DIFF
--- a/dataactvalidator/interfaces/validatorStagingInterface.py
+++ b/dataactvalidator/interfaces/validatorStagingInterface.py
@@ -5,6 +5,7 @@ class ValidatorStagingInterface(BaseInterface):
     """ Manages all interaction with the staging database """
 
     dbName = CONFIG_DB['staging_db_name']
+    dbConfig = CONFIG_DB
     Session = None
     engine = None
     session = None

--- a/dataactvalidator/interfaces/validatorValidationInterface.py
+++ b/dataactvalidator/interfaces/validatorValidationInterface.py
@@ -10,6 +10,7 @@ class ValidatorValidationInterface(BaseInterface) :
     """ Manages all interaction with the validation database """
 
     dbName = CONFIG_DB['validator_db_name']
+    dbConfig = CONFIG_DB
     Session = None
     engine = None
     session = None


### PR DESCRIPTION
Add flexibility to the database interfaces by passing db config info to the base interface rather than having the base interface reading it directly from the config file.