### PR TITLE
Db 308 override dbconfig

### DIFF
--- a/dataactvalidator/interfaces/validatorStagingInterface.py
+++ b/dataactvalidator/interfaces/validatorStagingInterface.py
@@ -5,6 +5,7 @@ class ValidatorStagingInterface(BaseInterface):
     """ Manages all interaction with the staging database """
 
     dbConfig = CONFIG_DB
+    dbName = dbConfig['staging_db_name']
     Session = None
     engine = None
     session = None

--- a/dataactvalidator/interfaces/validatorStagingInterface.py
+++ b/dataactvalidator/interfaces/validatorStagingInterface.py
@@ -4,14 +4,14 @@ from dataactcore.config import CONFIG_DB
 class ValidatorStagingInterface(BaseInterface):
     """ Manages all interaction with the staging database """
 
-    dbName = CONFIG_DB['staging_db_name']
     dbConfig = CONFIG_DB
     Session = None
     engine = None
     session = None
 
     def __init__(self):
-        super(ValidatorStagingInterface,self).__init__()
+        self.dbName = self.dbConfig['staging_db_name']
+        super(ValidatorStagingInterface, self).__init__()
 
     @staticmethod
     def getDbName():

--- a/dataactvalidator/interfaces/validatorValidationInterface.py
+++ b/dataactvalidator/interfaces/validatorValidationInterface.py
@@ -6,17 +6,17 @@ from dataactvalidator.filestreaming.fieldCleaner import FieldCleaner
 from dataactcore.config import CONFIG_DB
 
 
-class ValidatorValidationInterface(BaseInterface) :
+class ValidatorValidationInterface(BaseInterface):
     """ Manages all interaction with the validation database """
 
-    dbName = CONFIG_DB['validator_db_name']
     dbConfig = CONFIG_DB
     Session = None
     engine = None
     session = None
 
     def __init__(self):
-        super(ValidatorValidationInterface,self).__init__()
+        self.dbName = self.dbConfig['validator_db_name']
+        super(ValidatorValidationInterface, self).__init__()
 
     @classmethod
     def getCredDict(cls):

--- a/dataactvalidator/interfaces/validatorValidationInterface.py
+++ b/dataactvalidator/interfaces/validatorValidationInterface.py
@@ -10,6 +10,7 @@ class ValidatorValidationInterface(BaseInterface):
     """ Manages all interaction with the validation database """
 
     dbConfig = CONFIG_DB
+    dbName = dbConfig['validator_db_name']
     Session = None
     engine = None
     session = None

--- a/tests/baseTest.py
+++ b/tests/baseTest.py
@@ -1,27 +1,48 @@
 import unittest
-from webtest import TestApp
-from dataactvalidator.app import createApp
-from dataactvalidator.interfaces.interfaceHolder import InterfaceHolder
-from dataactcore.scripts.clearJobs import clearJobs
 import os
 import inspect
 import time
+from random import randint
+from webtest import TestApp
+from dataactvalidator.app import createApp
+from dataactvalidator.interfaces.interfaceHolder import InterfaceHolder
+from dataactcore.scripts.databaseSetup import dropDatabase
+from dataactcore.scripts.setupJobTrackerDB import setupJobTrackerDB
+from dataactcore.scripts.setupErrorDB import setupErrorDB
+from dataactvalidator.scripts.setupStagingDB import setupStagingDB
+from dataactvalidator.scripts.setupValidationDB import setupValidationDB
 from boto.s3.connection import S3Connection
 from boto.s3.key import Key
 from dataactcore.aws.s3UrlHandler import s3UrlHandler
 from dataactcore.models.jobModels import JobStatus, Submission
-from dataactcore.config import CONFIG_BROKER, CONFIG_SERVICES
 from dataactvalidator.models.validationModels import FileColumn
+from dataactcore.config import CONFIG_SERVICES, CONFIG_BROKER
+import dataactcore.config
 
 
 class BaseTest(unittest.TestCase):
     """ Test login, logout, and session handling """
 
-
     @classmethod
     def setUpClass(cls):
         """Set up resources to be shared within a test class"""
         #TODO: refactor into a pytest class fixtures and inject as necessary
+
+        # update application's db config options so unittests
+        # run against test databases
+        config = dataactcore.config.CONFIG_DB
+        cls.num = randint(1, 9999)
+        config['error_db_name'] = 'unittest{}_{}'.format(
+            cls.num, config['error_db_name'])
+        config['job_db_name'] = 'unittest{}_{}'.format(
+            cls.num, config['job_db_name'])
+        config['user_db_name'] = 'unittest{}_{}'.format(
+            cls.num, config['user_db_name'])
+        config['validator_db_name'] = 'unittest{}_{}'.format(
+            cls.num, config['validator_db_name'])
+        config['staging_db_name'] = 'unittest{}_{}'.format(
+            cls.num, config['staging_db_name'])
+        dataactcore.config.CONFIG_DB = config
 
         app = createApp()
         app.config['TESTING'] = True
@@ -35,8 +56,17 @@ class BaseTest(unittest.TestCase):
         cls.uploadFiles = True
         # Run tests for local broker or not
         cls.local = CONFIG_BROKER['local']
-        # This needs to be set to the local dirctory for error reports if local is True
+        # This needs to be set to the local directory for error reports if local is True
         cls.local_file_directory = CONFIG_SERVICES['error_report_path']
+
+        # drop and re-create test job db/tables
+        setupJobTrackerDB(hardReset=True)
+        # drop and re-create test error db/tables
+        setupErrorDB(hardReset=True)
+        # drop and re-create test staging db
+        setupStagingDB()
+        # drop and re-create test vaidation db
+        setupValidationDB(True)
 
         cls.interfaces = InterfaceHolder()
         cls.jobTracker = cls.interfaces.jobDb
@@ -52,6 +82,10 @@ class BaseTest(unittest.TestCase):
     def tearDownClass(cls):
         """Tear down class-level resources."""
         cls.interfaces.close()
+        dropDatabase(cls.interfaces.jobDb.dbName)
+        dropDatabase(cls.interfaces.errorDb.dbName)
+        dropDatabase(cls.interfaces.stagingDb.dbName)
+        dropDatabase(cls.interfaces.validationDb.dbName)
 
     def tearDown(self):
         """Tear down broker unit tests."""

--- a/tests/baseTest.py
+++ b/tests/baseTest.py
@@ -30,18 +30,19 @@ class BaseTest(unittest.TestCase):
 
         # update application's db config options so unittests
         # run against test databases
+        suite = cls.__name__.lower()
         config = dataactcore.config.CONFIG_DB
         cls.num = randint(1, 9999)
-        config['error_db_name'] = 'unittest{}_{}'.format(
-            cls.num, config['error_db_name'])
-        config['job_db_name'] = 'unittest{}_{}'.format(
-            cls.num, config['job_db_name'])
-        config['user_db_name'] = 'unittest{}_{}'.format(
-            cls.num, config['user_db_name'])
-        config['validator_db_name'] = 'unittest{}_{}'.format(
-            cls.num, config['validator_db_name'])
-        config['staging_db_name'] = 'unittest{}_{}'.format(
-            cls.num, config['staging_db_name'])
+        config['error_db_name'] = 'unittest{}_{}_error_data'.format(
+            cls.num, suite)
+        config['job_db_name'] = 'unittest{}_{}_job_tracker'.format(
+            cls.num, suite)
+        config['user_db_name'] = 'unittest{}_{}_user_manager'.format(
+            cls.num, suite)
+        config['validator_db_name'] = 'unittest{}_{}_validator'.format(
+            cls.num, suite)
+        config['staging_db_name'] = 'unittest{}_{}_staging'.format(
+            cls.num, suite)
         dataactcore.config.CONFIG_DB = config
 
         app = createApp()

--- a/tests/fileTypeTests.py
+++ b/tests/fileTypeTests.py
@@ -1,4 +1,3 @@
-from dataactvalidator.scripts import setupStagingDB
 from dataactvalidator.models.validationModels import TASLookup
 from dataactvalidator.filestreaming.schemaLoader import SchemaLoader
 from dataactvalidator.scripts.tasSetup import loadTAS
@@ -17,9 +16,6 @@ class FileTypeTests(BaseTest):
         # TODO: get rid of this flag once we're using a tempdb for test fixtures
         force_tas_load = False
 
-        # Create staging database
-        setupStagingDB.setupStagingDB()
-
         # Upload needed files to S3
         s3FileNameValid = cls.uploadFile("appropValid.csv", user)
         s3FileNameMixed = cls.uploadFile("appropMixed.csv", user)
@@ -31,7 +27,6 @@ class FileTypeTests(BaseTest):
         s3FileNameAwardMixed = cls.uploadFile("awardMixed.csv", user)
 
         # Create submissions and get IDs back
-
         submissionIDs = {}
         for i in range(0, 10):
             submissionIDs[i] = cls.insertSubmission(cls.jobTracker, user)
@@ -60,15 +55,6 @@ class FileTypeTests(BaseTest):
 
         # Load fields and rules
         FileTypeTests.load_definitions(cls.interfaces, force_tas_load)
-
-        # Remove existing tables from staging if they exist
-        for jobId in jobIdDict.values():
-            try:
-                cls.stagingDb.dropTable("job{}".format(jobId))
-            except Exception as e:
-                # Close and replace session
-                cls.stagingDb.session.close()
-                cls.stagingDb.session = cls.stagingDb.Session()
 
         cls.jobIdDict = jobIdDict
 
@@ -135,12 +121,6 @@ class FileTypeTests(BaseTest):
         jobId = self.jobIdDict["awardMixed"]
         self.passed = self.run_test(
             jobId, 200, "finished", 3185, 7, "complete", 44)
-
-    @classmethod
-    def tearDownClass(cls):
-        """Tear down class-wide resources."""
-        super(FileTypeTests, cls).tearDownClass()
-        # TODO: clean up databases
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/jobTests.py
+++ b/tests/jobTests.py
@@ -1,9 +1,5 @@
 from __future__ import print_function
-import json
-from dataactcore.models.jobModels import Status, JobDependency
-from dataactcore.scripts.clearErrors import clearErrors
-from dataactvalidator.scripts.setupValidationDB import setupValidationDB
-from dataactvalidator.scripts.setupStagingDB import setupStagingDB
+from dataactcore.models.jobModels import JobDependency
 from dataactvalidator.models.validationModels import Rule
 from baseTest import BaseTest
 import unittest
@@ -19,9 +15,6 @@ class JobTests(BaseTest):
         # Flag for testing a million+ errors (can take ~30 min to run)
         cls.includeLongTests = False
 
-        # Prep databases
-        setupStagingDB()
-        setupValidationDB(True)
         validationDb = cls.validationDb
         jobTracker = cls.jobTracker
 
@@ -30,8 +23,6 @@ class JobTests(BaseTest):
                 "appropriations", "program_activity"]:
             validationDb.removeRulesByFileType(fileType)
             validationDb.removeColumnsByFileType(fileType)
-        # Clear databases and run setup
-        clearErrors()
 
         # Create submissions and get IDs back
         submissionIDs = {}
@@ -133,12 +124,6 @@ class JobTests(BaseTest):
                 cls.stagingDb.session = cls.stagingDb.Session()
 
         cls.jobIdDict = jobIdDict
-
-    @classmethod
-    def tearDownClass(cls):
-        """Tear down JobTest resources."""
-        super(JobTests, cls).tearDownClass()
-        #TODO: clear jobs, drop staging tables
 
     def test_valid_job(self):
         """Test valid job."""


### PR DESCRIPTION
Update validator to accommodate [DB-308](https://federal-spending-transparency.atlassian.net/browse/DB-308):

* Interfaces now reset dbname based on changes that other modules (e.g., unit tests) make to the database config settings.
* Update the db names in the application config, setting them to temporary database names that will be used during the unit tests.
* Do all database setup in the baseTest class setup. This is because the test databases need to exist before the handlers can be instantiated and passed around to the individual test suites.
* Drop the temporary databases during the class tear-down method.