### PR TITLE
DB-253 Create SUM, SUM_TO_VALUE and tests

### DIFF
--- a/dataactvalidator/models/validationModels.py
+++ b/dataactvalidator/models/validationModels.py
@@ -30,7 +30,7 @@ class RuleType(Base):
     description = Column(Text)
 
     TYPE_DICT = None
-    TYPE_LIST = ["TYPE", "EQUAL","NOT EQUAL","LESS","GREATER","LENGTH","IN_SET"]
+    TYPE_LIST = ["TYPE", "EQUAL","NOT EQUAL","LESS","GREATER","LENGTH","IN_SET","SUM"]
 
 class MultiFieldRuleType(Base):
     __tablename__ = "multi_field_rule_type"
@@ -41,7 +41,7 @@ class MultiFieldRuleType(Base):
 
     session = None
     TYPE_DICT = None
-    TYPE_LIST = ["CAR_MATCH"]
+    TYPE_LIST = ["CAR_MATCH", "SUM_TO_VALUE"]
 
 class FileColumn(Base):
     __tablename__ = "file_columns"

--- a/dataactvalidator/scripts/setupValidationDB.py
+++ b/dataactvalidator/scripts/setupValidationDB.py
@@ -41,7 +41,8 @@ def setupValidationDB(hardReset = False):
         (6, 'LENGTH', 'string length'),
         (7, 'IN_SET', 'value must be in set'),
         (8, 'MIN LENGTH', 'length of data must be at least reference value'),
-        (9, 'REQUIRED_CONDITIONAL', 'field is required if secondary rule passes')
+        (9, 'REQUIRED_CONDITIONAL', 'field is required if secondary rule passes'),
+        (10, 'SUM', 'field is equal to the sum of other fields')
         ]
     for r in ruleTypeList:
         ruleType = RuleType(rule_type_id=r[0], name=r[1], description=r[2])
@@ -58,7 +59,9 @@ def setupValidationDB(hardReset = False):
         validatorDb.session.merge(fieldType)
 
     # insert multi-field rule types
-    mfrTypeList = [(1, 'CAR_MATCH', 'Matching a set of fields against a CAR file')]
+    mfrTypeList = [(1, 'CAR_MATCH', 'Matching a set of fields against a CAR file'),
+                   (2, 'SUM_TO_VALUE', 'Sum a set of fields and compare to specified value')
+                   ]
     for m in mfrTypeList:
         mfrt = MultiFieldRuleType(
             multi_field_rule_type_id = m[0], name=m[1], description=m[2])

--- a/tests/validatorTests.py
+++ b/tests/validatorTests.py
@@ -1,6 +1,10 @@
 import unittest
 from decimal import *
-from dataactvalidator.models.validationModels import FieldType, RuleType, FileColumn, Rule
+
+from dataactcore.models.baseInterface import BaseInterface
+from dataactvalidator.interfaces.validatorValidationInterface import ValidatorValidationInterface
+from dataactvalidator.models.validationModels import FieldType, RuleType, FileColumn, Rule, MultiFieldRule, \
+    MultiFieldRuleType
 from dataactvalidator.validation_handlers.validator import Validator
 from baseTest import BaseTest
 
@@ -172,6 +176,10 @@ class ValidatorTests(BaseTest):
         notRule.name = "NOT EQUAL"
         setRule = RuleType()
         setRule.name = "IN_SET"
+        sumRule = RuleType()
+        sumRule.name = "SUM"
+        sumToValueRule = MultiFieldRuleType()
+        sumToValueRule.name = "SUM_TO_VALUE"
 
         schema = self.schema
         interfaces = self.interfaces
@@ -223,14 +231,32 @@ class ValidatorTests(BaseTest):
         rule8.rule_text_1 = "X, F, A"
         rule8.rule_timing_id = 1
 
-        rules = [rule1, rule2, rule3, rule4, rule5, rule6, rule7, rule8]
+        rule9 = Rule()
+        rule9.rule_type = sumRule
+        rule9.file_column = schema["test2"]
+        rule9.rule_text_1 = "test7"
+        rule9.rule_text_2 = "test2,test4,test5"
+        rule9.rule_timing_id = 1
+
+        rule10 = MultiFieldRule()
+        rule10.rule_type = sumToValueRule
+        rule10.rule_text_1 = "46"
+        rule10.rule_text_2 = "test2,test4,test5"
+        rule10.rule_timing_id = 1
+
+        vvi = ValidatorValidationInterface()
+        fileId = vvi.getFileId("award")
+        vvi.addMultiFieldRule(fileId, "SUM_TO_VALUE", rule10.rule_text_1, rule10.rule_text_2, "Evaluates the sum of fields to a number")
+
+        rules = [rule1, rule2, rule3, rule4, rule5, rule6, rule7, rule8, rule9]
         record = {
             "test1": "hello",
             "test2": "1.0",
             "test3": "YES",
             "test4": "44",
             "test5": "1",
-            "test6": "X"
+            "test6": "X",
+            "test7": "46"
         }
         self.assertTrue(Validator.validate(
             record, rules, schema, "award", self.interfaces)[0])
@@ -241,7 +267,8 @@ class ValidatorTests(BaseTest):
             "test3": "NO",
             "test4": "45",
             "test5": "1",
-            "test6": "Q"
+            "test6": "Q",
+            "test7": "46.5"
         }
         self.assertFalse(Validator.validate(
             record, [rule3], schema, "award", interfaces)[0])
@@ -255,6 +282,8 @@ class ValidatorTests(BaseTest):
             record, [rule7], schema, "award", interfaces)[0])
         self.assertFalse(Validator.validate(
             record, [rule8], schema, "award", interfaces)[0])
+        self.assertFalse(Validator.validate(
+            record, [rule9], schema, "award", interfaces)[0])
         self.assertFalse(Validator.validate(
             record, rules, schema, "award", interfaces)[0])
 


### PR DESCRIPTION
[DB-253]

* Created extra Rule ‘SUM’ which checks that the field specified in
rule_text_1 is equal to the sum of (comma-delimited list of) fields in
rule_text_2 (as Decimals)

* Created MultiFieldRule “SUM_TO_VALUE” that evaluates if the sum of
the (comma-delimited list of) fields in rule_text_2 is equal to the
number (Decimal) specified in rule_text_1

* Fixed a problem where the error message generating code would cause
an error due to assuming rule_text_1 was a list of fields for
MultiFieldRules

* Created unit tests for both of these rules

* Edited set up scripts to include these rule types in the database.
We’ll need to update dev RDS/etc. when merged in